### PR TITLE
Add OPTIONS HTTP method to CORS allowed_methods in API's utils file

### DIFF
--- a/src/api/utils.rs
+++ b/src/api/utils.rs
@@ -17,7 +17,7 @@ pub fn post_cors() -> warp::cors::Builder {
             "Access-Control-Allow-Headers",
             "Content-Type",
         ])
-        .allow_methods(vec!["POST"])
+        .allow_methods(vec!["POST", "OPTIONS"])
 }
 
 /// Easy and simple GET CORS
@@ -36,7 +36,7 @@ pub fn get_cors() -> warp::cors::Builder {
             "Access-Control-Allow-Headers",
             "Content-Type",
         ])
-        .allow_methods(vec!["GET"])
+        .allow_methods(vec!["GET", "OPTIONS"])
 }
 
 /// Clone component/struct to use in route


### PR DESCRIPTION
Title: Add OPTIONS HTTP method to allowed_methods in CORS

Description:
This PR aims to add the OPTIONS HTTP method to the allowed_methods list for Cross-Origin Resource Sharing (CORS) in our API. The changes are isolated and restricted to the utils file in the API directory.

**Summary of Changes**
- OPTIONS method added to the allowed_methods list for CORS in the API utils file.

**Motivation**
The user requested to enable OPTIONS method, which is commonly used as a pre-flight request to check server's understanding of the CORS protocol. It will further allow OPTIONS HTTP method to be called from different domains, enhancing the cross-domain interaction capacity of our API.

**Context or Background**
The OPTIONS method is an HTTP request method that describes the communication options for the target resource, or the server's controller functionality. By adding it to our list of allowed methods, we're promoting greater interoperability between different domains and making our API more robust and flexible.

**Testing Instructions**
To verify the successful implementation of the OPTIONS method, make a pre-flight request from a different domain and confirm that it doesn't result in a CORS error. 

**Known Issues/Limitations**
There are no known issues or limitations with this PR.

As we mature our CORS support, additional updates and modifications may be required in future, in accordance with the user or project requirements.